### PR TITLE
Add overview modal page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -23,6 +23,7 @@ import EditAppointmentPage from './pages/EditAppointmentPage';
 import AppointmentsPage from './pages/AppointmentsPage';
 import PricingPage from './pages/PricingPage';
 import FeaturesPage from './pages/FeaturesPage';
+import OverviewPage from './pages/OverviewPage';
 
 function AppContent() {
   const location = useLocation();
@@ -52,6 +53,7 @@ function AppContent() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/pricing" element={<PricingPage />} />
         <Route path="/features" element={<FeaturesPage />} />
+        <Route path="/overview" element={<OverviewPage />} />
         <Route path="/dashboard" element={<PrivateRoute><DashboardPage /></PrivateRoute>} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -1,6 +1,7 @@
 import POWERLogo from '../assets/POWER_IT.png';
+import { Link } from 'react-router-dom';
 
-export const Footer = ({ pricingLink = "#pricing", featuresLink = "#features" }) => {
+export const Footer = ({ pricingLink = "/pricing", featuresLink = "/features" }) => {
   return (
     <div className="footer-section">
       <div className="footer-container">
@@ -21,9 +22,9 @@ export const Footer = ({ pricingLink = "#pricing", featuresLink = "#features" })
           <div className="footer-column">
             <div className="footer-column-title">Product</div>
             <div className="footer-links">
-              <a href="#overview" className="footer-link">Overview</a>
-              <a href={pricingLink} className="footer-link">Pricing</a>
-              <a href={featuresLink} className="footer-link">Features</a>
+              <Link to="/overview" className="footer-link">Overview</Link>
+              <Link to={pricingLink} className="footer-link">Pricing</Link>
+              <Link to={featuresLink} className="footer-link">Features</Link>
             </div>
           </div>
 

--- a/frontend/src/pages/OverviewPage.js
+++ b/frontend/src/pages/OverviewPage.js
@@ -1,0 +1,32 @@
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+export const OverviewPage = () => {
+  const navigate = useNavigate();
+
+  const handleClose = () => {
+    navigate(-1); // go back to previous page
+  };
+
+  return (
+    <Dialog open onClose={handleClose} maxWidth="md" fullWidth>
+      <DialogTitle>Application Overview</DialogTitle>
+      <DialogContent dividers>
+        <div style={{ textAlign: 'center', marginBottom: '1rem' }}>
+          {/* Image placeholder */}
+          <div style={{ width: '100%', height: '200px', background: '#ccc', display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: '8px' }}>
+            <Typography variant="subtitle1">Image Placeholder</Typography>
+          </div>
+        </div>
+        <Typography variant="body1" paragraph>
+          POWER IT is a healthcare scheduling system built with a Django backend and React frontend. Clinics can upload events, holidays, staff lists and provider lists directly from the app, manage availability and block times, and send automated text and email reminders. Notifications keep both organization and system administrators informed whenever patients register or appointments are created, ensuring seamless collaboration across the team.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} variant="contained">Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default OverviewPage;


### PR DESCRIPTION
## Summary
- implement OverviewPage as a modal
- link to `/overview` from footer
- register route in `App.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421b31b0f0832a89ceb5ad771bc1fd