### PR TITLE
Convert SettingsPage buttons to tabs

### DIFF
--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -1,143 +1,82 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import MaintenancePage from './MaintenancePage'; // Import your existing maintenance page
-import EnvironmentProfilePage from './EnvironmentProfilePage'; // Create this component as step 2
-import UploadTab from '../components/UploadTab'; // Correct import path for UploadTab
+import MaintenancePage from './MaintenancePage';
+import EnvironmentProfilePage from './EnvironmentProfilePage';
+import UploadTab from '../components/UploadTab';
 import BackButton from '../components/BackButton';
 import {
   Box,
   Typography,
-  Button,
-  Stack
+  Tabs,
+  Tab
 } from '@mui/material';
-import BuildIcon from '@mui/icons-material/Build';
-import SettingsApplicationsIcon from '@mui/icons-material/SettingsApplications';
-import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 
 function SettingsPage() {
-  const [view, setView] = useState(''); // '' | 'maintenance' | 'env' | 'uploads'
-  const navigate = useNavigate();
+  const [tab, setTab] = useState('maintenance');
 
   return (
     <div style={{ textAlign: 'left', width: '100%' }}>
-      <Box sx={{ 
-        boxShadow: 2, 
-        borderRadius: 2, 
-        bgcolor: 'background.paper', 
-        p: 3,
-        width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        textAlign: 'left' // Override global text-align: center
-      }}>
-
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', mb: 2 }}>
-          <Typography variant="h5" sx={{ textAlign: 'left' }}>Settings</Typography>
-          <BackButton 
-            onClick={() => {
-              if (view) {
-                setView('');
-              } else {
-                navigate(-1);
-              }
+      <Box sx={{ mt: 0, boxShadow: 2, borderRadius: 2, bgcolor: 'background.paper', p: 3 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            mb: 1,
+            borderRadius: 2,
+            bgcolor: '#f5faff',
+            boxShadow: 1,
+            minHeight: 48,
+            p: 1,
+          }}
+        >
+          <Tabs
+            value={tab}
+            onChange={(_, val) => setTab(val)}
+            sx={{
+              flex: 1,
+              minHeight: 40,
+              '& .MuiTabs-indicator': {
+                height: 4,
+                borderRadius: 2,
+                bgcolor: 'primary.main',
+              },
+              '& .MuiTab-root': {
+                fontWeight: 500,
+                fontSize: '1rem',
+                color: 'primary.main',
+                minHeight: 40,
+                textTransform: 'none',
+                borderRadius: 2,
+                mx: 0.5,
+                transition: 'background 0.2s',
+                '&.Mui-selected': {
+                  bgcolor: 'primary.light',
+                  color: 'primary.dark',
+                  boxShadow: 2,
+                },
+                '&:hover': {
+                  bgcolor: 'primary.lighter',
+                  color: 'primary.dark',
+                },
+              },
             }}
-          />
+          >
+            <Tab label="Schedule Maintenance" value="maintenance" />
+            <Tab label="Environment Profile" value="env" />
+            <Tab label="Uploads / Downloads" value="uploads" />
+          </Tabs>
+          <Box sx={{ ml: 1 }}>
+            <BackButton />
+          </Box>
         </Box>
 
-        <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
-          {view === 'maintenance' && <MaintenancePage />}
-          {view === 'env' && <EnvironmentProfilePage />}
-          {view === 'uploads' && (
-            <Box sx={{ boxShadow: 2, borderRadius: 2, bgcolor: 'background.paper', p: 3, mt: 2 }}>
-              <Typography variant="h6" sx={{ mb: 2 }}>Uploads / Downloads</Typography>
-              <UploadTab />
-            </Box>
-          )}
-          {!view && (
-            <Stack 
-              direction="row" 
-              spacing={2} 
-              sx={{ 
-                mb: 4, 
-                justifyContent: 'flex-start', 
-                alignItems: 'flex-start',
-                textAlign: 'left',
-                //width: '100%'
-              }}
-            >
-              <Button
-                variant="contained"
-                color="primary"
-                sx={{
-                  width: 120,
-                  height: 120,
-                  flexDirection: 'column',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  textAlign: 'center',
-                  fontWeight: 'normal',
-                  fontSize: '1.1rem',
-                  borderRadius: 2,
-                  boxShadow: 1,
-                  textTransform: 'none',
-                  fontFamily: 'inherit',
-                }}
-                onClick={() => setView('maintenance')}
-              >
-                <BuildIcon sx={{ fontSize: 36, mb: 1 }} />
-                Schedule Maintenance
-              </Button>
-              <Button
-                variant="contained"
-                color="secondary"
-                sx={{
-                  width: 120,
-                  height: 120,
-                  flexDirection: 'column',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  textAlign: 'center',
-                  fontWeight: 'normal',
-                  fontSize: '1.1rem',
-                  borderRadius: 2,
-                  boxShadow: 1,
-                  textTransform: 'none',
-                  fontFamily: 'inherit',
-                }}
-                onClick={() => setView('env')}
-              >
-                <SettingsApplicationsIcon sx={{ fontSize: 36, mb: 1 }} />
-                Environment Profile
-              </Button>
-              <Button
-                variant="contained"
-                color="success"
-                sx={{
-                  width: 120,
-                  height: 120,
-                  flexDirection: 'column',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  textAlign: 'center',
-                  fontWeight: 'normal',
-                  fontSize: '1.1rem',
-                  borderRadius: 2,
-                  boxShadow: 1,
-                  textTransform: 'none',
-                  fontFamily: 'inherit',
-                }}
-                onClick={() => setView('uploads')}
-              >
-                <CloudUploadIcon sx={{ fontSize: 36, mb: 1 }} />
-                Uploads / Downloads
-              </Button>
-            </Stack>
-          )}
-        </Box>
+        {tab === 'maintenance' && <MaintenancePage />}
+        {tab === 'env' && <EnvironmentProfilePage />}
+        {tab === 'uploads' && (
+          <Box sx={{ boxShadow: 2, borderRadius: 2, bgcolor: 'background.paper', p: 3, mt: 2 }}>
+            <Typography variant="h6" sx={{ mb: 2 }}>Uploads / Downloads</Typography>
+            <UploadTab />
+          </Box>
+        )}
       </Box>
     </div>
   );


### PR DESCRIPTION
## Summary
- rework SettingsPage to use a tab layout similar to PatientsPage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842386e5068832a82a03d49e7ad66f7