### PR TITLE
Add Team tab with staff list

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -19,6 +19,7 @@ from .views import (
     DownloadProvidersCSVTemplate,
     UploadProvidersCSV,
     get_current_user,
+    get_team_members,
 )
 
 router = DefaultRouter()
@@ -43,6 +44,7 @@ urlpatterns = [
     path('patients/<int:user_id>/', PatientDeleteView.as_view(), name='patient-delete'),
     path('providers/download-template/', DownloadProvidersCSVTemplate.as_view(), name='providers-download-template'),
     path('providers/upload-csv/', UploadProvidersCSV.as_view(), name='providers-upload-csv'),
+    path('team/', get_team_members, name='team-list'),
 ]
 
 # ✅ Append viewset routes


### PR DESCRIPTION
## Summary
- add new API endpoint `get_team_members` for non-patient profiles
- expose new route `/api/users/team/`
- extend Patients page with a Team tab listing providers/staff

## Testing
- `python manage.py test --verbosity 2` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68427405abcc832a8abd99931c4693f8