### PR TITLE
Add auto email settings tab

### DIFF
--- a/frontend/src/pages/AutoEmailSetUpPage.js
+++ b/frontend/src/pages/AutoEmailSetUpPage.js
@@ -1,0 +1,110 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import {
+  Box,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button,
+  Alert,
+  CircularProgress,
+  Stack
+} from '@mui/material';
+
+function AutoEmailSetUpPage() {
+  const [frequency, setFrequency] = useState('weekly');
+  const [dayOfWeek, setDayOfWeek] = useState(1);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchSettings() {
+      setLoading(true);
+      try {
+        const token = localStorage.getItem('access_token');
+        const res = await axios.get('http://127.0.0.1:8000/api/settings/environment/', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setFrequency(res.data.auto_message_frequency || 'weekly');
+        setDayOfWeek(res.data.auto_message_day_of_week || 1);
+      } catch (err) {
+        setStatus('Failed to load settings.');
+        console.error(err);
+      }
+      setLoading(false);
+    }
+    fetchSettings();
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setStatus('');
+    try {
+      const token = localStorage.getItem('access_token');
+      await axios.post(
+        'http://127.0.0.1:8000/api/settings/environment/',
+        {
+          auto_message_frequency: frequency,
+          auto_message_day_of_week: dayOfWeek
+        },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setStatus('Settings Saved!');
+    } catch (e) {
+      setStatus('Failed to save settings.');
+      console.error(e);
+    }
+    setSaving(false);
+  };
+
+  return (
+    <Box sx={{ boxShadow: 2, borderRadius: 2, bgcolor: 'background.paper', p: 3 }}>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Auto Message Frequency
+      </Typography>
+      <Stack spacing={2} sx={{ maxWidth: 300 }}>
+        <FormControl fullWidth>
+          <InputLabel id="frequency-label">Frequency</InputLabel>
+          <Select
+            labelId="frequency-label"
+            value={frequency}
+            label="Frequency"
+            onChange={(e) => setFrequency(e.target.value)}
+          >
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="bi-weekly">Bi-weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </Select>
+        </FormControl>
+        <FormControl fullWidth>
+          <InputLabel id="day-label">Day of Week</InputLabel>
+          <Select
+            labelId="day-label"
+            value={dayOfWeek}
+            label="Day of Week"
+            onChange={(e) => setDayOfWeek(Number(e.target.value))}
+          >
+            <MenuItem value={1}>Monday</MenuItem>
+            <MenuItem value={2}>Tuesday</MenuItem>
+            <MenuItem value={3}>Wednesday</MenuItem>
+            <MenuItem value={4}>Thursday</MenuItem>
+            <MenuItem value={5}>Friday</MenuItem>
+            <MenuItem value={6}>Saturday</MenuItem>
+            <MenuItem value={0}>Sunday</MenuItem>
+          </Select>
+        </FormControl>
+        <Button variant="contained" onClick={handleSave} disabled={saving || loading}>
+          {saving ? <CircularProgress size={24} /> : 'Save Settings'}
+        </Button>
+        {status && (
+          <Alert severity={status === 'Settings Saved!' ? 'success' : 'error'}>{status}</Alert>
+        )}
+      </Stack>
+    </Box>
+  );
+}
+
+export default AutoEmailSetUpPage;

--- a/frontend/src/pages/MessagesPage.js
+++ b/frontend/src/pages/MessagesPage.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Box, Tabs, Tab, Typography } from '@mui/material';
+import AutoEmailSetUpPage from './AutoEmailSetUpPage';
 import { useNavigate } from 'react-router-dom';
 import { jwtDecode } from 'jwt-decode';
 import BackButton from '../components/BackButton';
@@ -81,11 +82,7 @@ function MessagesPage() {
           <BackButton to="/admin" />
         </Box>
       </Box>
-      {tab === 'email' && (
-        <Typography variant="body1" sx={{ p: 2 }}>
-          Email messaging coming soon.
-        </Typography>
-      )}
+      {tab === 'email' && <AutoEmailSetUpPage />}
       {tab === 'sms' && (
         <Typography variant="body1" sx={{ p: 2 }}>
           SMS messaging coming soon.


### PR DESCRIPTION
## Summary
- implement `AutoEmailSetUpPage` component for configuring automatic email frequency and day-of-week
- display `AutoEmailSetUpPage` within the Email tab on `MessagesPage`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68435f9c7258832aa50ed569563ce5e4