### PR TITLE
Add data security page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -28,13 +28,14 @@ import OverviewPage from './pages/OverviewPage';
 import AboutPage from './pages/AboutPage';
 import ContactPage from './pages/ContactPage';
 import EnrollmentPage from './pages/EnrollmentPage';
+import DataSecurityPage from './pages/DataSecurityPage';
 import ToastTestPage from './pages/ToastTestPage';
 import MessagesPage from './pages/MessagesPage';
 import ToastDebugButton from './components/ToastDebugButton';
 
 function AppContent() {
   const location = useLocation();
-  const showNavbar = !['/', '/login', '/register', '/forgot-password', '/pricing', '/features', '/overview', '/about', '/contact', '/enroll'].includes(location.pathname);
+  const showNavbar = !['/', '/login', '/register', '/forgot-password', '/pricing', '/features', '/overview', '/about', '/contact', '/enroll', '/security'].includes(location.pathname);
 
   // Add or remove body class based on whether navbar should be shown
   useEffect(() => {
@@ -72,6 +73,7 @@ function AppContent() {
         <Route path="/about" element={<AboutPage />} />
         <Route path="/contact" element={<ContactPage />} />
         <Route path="/overview" element={<OverviewPage />} />
+        <Route path="/security" element={<DataSecurityPage />} />
         <Route path="/dashboard" element={<PrivateRoute><DashboardPage /></PrivateRoute>} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />

--- a/frontend/src/DataSecurityPage/DataSecurityPage.css
+++ b/frontend/src/DataSecurityPage/DataSecurityPage.css
@@ -1,0 +1,83 @@
+/* ===================================================================
+   DATA SECURITY PAGE STYLES - Matches Landing Page theme
+   ================================================================= */
+.data-security-page {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-family: "Inter", sans-serif;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.page-title-section {
+  padding: 80px 64px 60px;
+  text-align: center;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+}
+
+.page-title {
+  font-size: 48px;
+  font-weight: 800;
+  color: #1e293b;
+  margin-bottom: 16px;
+  letter-spacing: -0.02em;
+}
+
+.page-subtitle {
+  font-size: 24px;
+  font-weight: 400;
+  color: #64748b;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.security-details {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 40px;
+  padding: 60px 64px;
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.text-block {
+  flex: 1;
+}
+
+.section-heading {
+  font-size: 32px;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 16px;
+}
+
+.section-text {
+  font-size: 18px;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.image-placeholder {
+  width: 300px;
+  height: 200px;
+  background: linear-gradient(135deg, #e2e8f0 0%, #f8fafc 100%);
+  border: 2px dashed #cbd5e1;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .security-details {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .image-placeholder {
+    width: 100%;
+    max-width: 400px;
+  }
+}

--- a/frontend/src/pages/DataSecurityPage.js
+++ b/frontend/src/pages/DataSecurityPage.js
@@ -1,0 +1,45 @@
+import '../DataSecurityPage/DataSecurityPage.css';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export const DataSecurityPage = ({ className }) => {
+  return (
+    <div className={`data-security-page ${className || ''}`}> 
+      <Header />
+      <div className="page-title-section">
+        <h1 className="page-title">Data Security & Privacy</h1>
+        <p className="page-subtitle">How POWER protects your information</p>
+      </div>
+      <div className="security-details">
+        <div className="text-block">
+          <h2 className="section-heading">End-to-End Encryption</h2>
+          <p className="section-text">
+            All communications between your browser and our servers are protected with industry standard encryption. Patient information and clinic data remain confidential while in transit and at rest.
+          </p>
+        </div>
+        <div className="image-placeholder" />
+      </div>
+      <div className="security-details">
+        <div className="text-block">
+          <h2 className="section-heading">Local Storage Options</h2>
+          <p className="section-text">
+            POWER can store your data locally on clinic infrastructure when required, ensuring you maintain complete ownership and control over every record.
+          </p>
+        </div>
+        <div className="image-placeholder" />
+      </div>
+      <div className="security-details">
+        <div className="text-block">
+          <h2 className="section-heading">Full Data Ownership</h2>
+          <p className="section-text">
+            Your data is never shared with third parties. You decide when and how to export or remove it, supporting strict HIPAA compliance and privacy requirements.
+          </p>
+        </div>
+        <div className="image-placeholder" />
+      </div>
+      <Footer pricingLink="/pricing" featuresLink="/features" />
+    </div>
+  );
+};
+
+export default DataSecurityPage;

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -41,6 +41,11 @@ export const LandingPageV1Desktop1920Px = ({ className, ...props }) => {  // Ini
       navigate('/pricing');
     }
   };
+
+  // Navigate to detailed data security page
+  const handleSecurityClick = () => {
+    navigate('/security');
+  };
   
   return (
     <div className={"landing-page-v-1-desktop-1920-px " + className}>
@@ -304,7 +309,7 @@ export const LandingPageV1Desktop1920Px = ({ className, ...props }) => {  // Ini
               professionals worldwide.
             </p>
             <div className="data-security-cta">
-              <div className="btn-read-more" onClick={handlePricingClick} style={{ cursor: 'pointer' }}>
+              <div className="btn-read-more" onClick={handleSecurityClick} style={{ cursor: 'pointer' }}>
                 <div className="read-more-text">Read more</div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- create dedicated DataSecurityPage with header and footer
- style the page following landing page theme
- link "Read More" button to new page
- register new `/security` route in the app

## Testing
- `npm test --silent --workspaces=false --if-present -- --watchAll=false`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845dbfa2108832abb3e25822815645d