### PR TITLE
Implement solutions page navigation

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -33,10 +33,11 @@ import SupportPage from './pages/SupportPage';
 import ToastTestPage from './pages/ToastTestPage';
 import MessagesPage from './pages/MessagesPage';
 import ToastDebugButton from './components/ToastDebugButton';
+import SolutionsPage from './pages/SolutionsPage';
 
 function AppContent() {
   const location = useLocation();
-  const showNavbar = !['/', '/login', '/register', '/forgot-password', '/pricing', '/features', '/overview', '/about', '/contact', '/enroll', '/security', '/support'].includes(location.pathname);
+  const showNavbar = !['/', '/login', '/register', '/forgot-password', '/pricing', '/features', '/overview', '/about', '/contact', '/enroll', '/security', '/support', '/solutions'].includes(location.pathname);
 
   // Add or remove body class based on whether navbar should be shown
   useEffect(() => {
@@ -48,7 +49,7 @@ function AppContent() {
   }, [showNavbar]);
   useEffect(() => {
     const body = document.body;
-    if (location.pathname === '/login' || location.pathname === '/register' || location.pathname === '/forgot-password' || location.pathname === '/pricing' || location.pathname === '/features' || location.pathname === '/overview' || location.pathname === '/about' || location.pathname === '/contact' || location.pathname === '/enroll' || location.pathname === '/support') {
+    if (location.pathname === '/login' || location.pathname === '/register' || location.pathname === '/forgot-password' || location.pathname === '/pricing' || location.pathname === '/features' || location.pathname === '/overview' || location.pathname === '/about' || location.pathname === '/contact' || location.pathname === '/enroll' || location.pathname === '/support' || location.pathname === '/solutions') {
       body.classList.add('bg-gray-100');
     } else {
       body.classList.remove('bg-gray-100');
@@ -76,6 +77,7 @@ function AppContent() {
         <Route path="/support" element={<SupportPage />} />
         <Route path="/overview" element={<OverviewPage />} />
         <Route path="/security" element={<DataSecurityPage />} />
+        <Route path="/solutions" element={<SolutionsPage />} />
         <Route path="/dashboard" element={<PrivateRoute><DashboardPage /></PrivateRoute>} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />

--- a/frontend/src/SolutionsPage/SolutionsPage.css
+++ b/frontend/src/SolutionsPage/SolutionsPage.css
@@ -1,0 +1,39 @@
+.solutions-page {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-family: "Inter", sans-serif;
+  background: #f8fafc;
+}
+
+.solutions-content {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 32px;
+  padding: 80px 32px;
+}
+
+.solution-button {
+  width: 200px;
+  height: 200px;
+  border-radius: 12px;
+  background: #1e293b;
+  color: #ffffff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 24px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s, background 0.2s;
+  text-align: center;
+  text-decoration: none;
+}
+
+.solution-button:hover {
+  transform: scale(1.05);
+  background: #334155;
+}

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -39,9 +39,9 @@ export const Header = ({ className }) => {
   const [showSolutionsDropdown, setShowSolutionsDropdown] = useState(false);
   const [showPricingDropdown, setShowPricingDropdown] = useState(false);
 
-  // Handler function to navigate to login page
+  // Handler function to navigate to the solutions page
   const handleLoginClick = () => {
-    navigate('/login');
+    navigate('/solutions');
   };
 
   // Handler function to navigate to landing page

--- a/frontend/src/pages/SolutionsPage.js
+++ b/frontend/src/pages/SolutionsPage.js
@@ -1,0 +1,31 @@
+import '../SolutionsPage/SolutionsPage.css';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import { useNavigate } from 'react-router-dom';
+
+export const SolutionsPage = ({ className }) => {
+  const navigate = useNavigate();
+  const handleSchedulerClick = () => {
+    navigate('/login');
+  };
+
+  return (
+    <div className={`solutions-page ${className || ''}`}>
+      <Header />
+      <div className="solutions-content">
+        <div className="solution-button" onClick={handleSchedulerClick} style={{cursor: 'pointer'}}>
+          Scheduler
+        </div>
+        <div className="solution-button" style={{cursor: 'pointer'}}>
+          Communicator
+        </div>
+        <div className="solution-button" style={{cursor: 'pointer'}}>
+          Portal
+        </div>
+      </div>
+      <Footer pricingLink="/pricing" featuresLink="/features" />
+    </div>
+  );
+};
+
+export default SolutionsPage;


### PR DESCRIPTION
## Summary
- add a new SolutionsPage with three square buttons
- route the Header login button to `/solutions`
- expose the new page in `App.js` routing logic
- style the solutions page

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684799dc05b4832a9698a5a3fdb5926d