### PR TITLE
Implement auto SMS reminders

### DIFF
--- a/appointments/cron.py
+++ b/appointments/cron.py
@@ -2,6 +2,8 @@ from django_cron import CronJobBase, Schedule
 from django.utils import timezone
 from django.core.mail import send_mail
 from django.core.cache import cache
+from twilio.rest import Client
+from django.conf import settings
 from datetime import timedelta
 from .models import Appointment, AutoEmail
 
@@ -114,3 +116,98 @@ class BlastPatientReminderCronJob(CronJobBase):
         print(f"Running cron job at {timezone.now()}")
         send_patient_reminders()
         print("Cron job completed")
+
+
+def send_patient_sms_reminders():
+    """Send SMS reminders to patients based on AutoEmail configuration."""
+    today = timezone.now().date()
+    current_weekday = timezone.now().weekday()
+
+    active_configs = AutoEmail.objects.filter(is_active=True)
+    if not active_configs.exists():
+        print("No active AutoEmail configurations found.")
+        return
+
+    sms_sent = cache.get('sms_patients_today', set())
+    new_sms_sent = set(sms_sent)
+
+    client = None
+    if settings.TWILIO_ACCOUNT_SID and settings.TWILIO_AUTH_TOKEN:
+        client = Client(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
+    else:
+        print("Twilio credentials not configured")
+        return
+
+    for config in active_configs:
+        if config.auto_message_start_date and config.auto_message_start_date > today:
+            continue
+
+        should_send = False
+        if config.auto_message_frequency == 'daily':
+            should_send = True
+        elif config.auto_message_frequency == 'weekly':
+            should_send = current_weekday == config.auto_message_day_of_week
+        elif config.auto_message_frequency == 'bi-weekly':
+            if current_weekday == config.auto_message_day_of_week:
+                if config.auto_message_start_date:
+                    days_since_start = (today - config.auto_message_start_date).days
+                    weeks_since_start = days_since_start // 7
+                    should_send = weeks_since_start % 2 == 0
+                else:
+                    should_send = True
+        elif config.auto_message_frequency == 'monthly':
+            if current_weekday == config.auto_message_day_of_week:
+                if config.auto_message_start_date:
+                    days_since_start = (today - config.auto_message_start_date).days
+                    weeks_since_start = days_since_start // 7
+                    should_send = weeks_since_start % 4 == 0
+                else:
+                    should_send = True
+
+        if not should_send:
+            continue
+
+        next_week = today + timedelta(days=7)
+        if config.organization:
+            appointments = Appointment.objects.filter(
+                appointment_datetime__date__gte=today,
+                appointment_datetime__date__lte=next_week,
+                organization=config.organization
+            ).select_related('patient')
+        else:
+            appointments = Appointment.objects.filter(
+                appointment_datetime__date__gte=today,
+                appointment_datetime__date__lte=next_week
+            ).select_related('patient')
+
+        for appt in appointments:
+            patient = appt.patient
+            phone = getattr(patient, 'phone_number', None)
+            if not patient or not phone or patient.id in sms_sent:
+                continue
+
+            appt_date = appt.appointment_datetime.strftime('%A, %B %d, %Y at %I:%M %p')
+            body = f"Hi {patient.first_name}, This is a reminder of your visit on: {appt_date}. Please arrive 15 minutes early."
+            try:
+                client.messages.create(
+                    body=body,
+                    from_=settings.TWILIO_PHONE_NUMBER,
+                    to=phone
+                )
+                new_sms_sent.add(patient.id)
+                print(f"Sent SMS to {phone} for appointment on {appt_date}")
+            except Exception as e:
+                print(f"Failed to send SMS to {phone}: {str(e)}")
+
+    cache.set('sms_patients_today', new_sms_sent, 24*60*60)
+
+
+class BlastPatientSMSReminderCronJob(CronJobBase):
+    RUN_AT_TIMES = ['18:00']
+    schedule = Schedule(run_at_times=RUN_AT_TIMES)
+    code = 'appointments.blast_patient_sms_reminder_cron'
+
+    def do(self):
+        print(f"Running SMS cron job at {timezone.now()}")
+        send_patient_sms_reminders()
+        print("SMS Cron job completed")

--- a/appointments/urls.py
+++ b/appointments/urls.py
@@ -1,6 +1,22 @@
 from rest_framework.routers import DefaultRouter
 from django.urls import path
-from .views import DownloadClinicEventsTemplate, UploadClinicEventsCSV, EnvironmentSettingView, AppointmentViewSet, doctor_available_slots, AvailabilityViewSet, HolidayViewSet, ClinicEventViewSet, DownloadAvailabilityTemplate, UploadAvailabilityCSV, RunWeeklyPatientRemindersView, RunPatientRemindersNowView, AutoEmailViewSet, update_appointment_status  # ⬅️ import the new view
+from .views import (
+    DownloadClinicEventsTemplate,
+    UploadClinicEventsCSV,
+    EnvironmentSettingView,
+    AppointmentViewSet,
+    doctor_available_slots,
+    AvailabilityViewSet,
+    HolidayViewSet,
+    ClinicEventViewSet,
+    DownloadAvailabilityTemplate,
+    UploadAvailabilityCSV,
+    RunWeeklyPatientRemindersView,
+    RunPatientRemindersNowView,
+    RunPatientSMSRemindersNowView,
+    AutoEmailViewSet,
+    update_appointment_status,
+)
 from .analytics_views import AnalyticsReportView, ExportReportView
 
 router = DefaultRouter()
@@ -21,6 +37,7 @@ urlpatterns = [
     path('availability/upload-csv/', UploadAvailabilityCSV.as_view(), name='upload-availability-csv'),
     path('run-weekly-patient-reminders/', RunWeeklyPatientRemindersView.as_view(), name='run-weekly-patient-reminders'),
     path('run-patient-reminders-now/', RunPatientRemindersNowView.as_view(), name='run-patient-reminders-now'),
+    path('run-patient-sms-reminders-now/', RunPatientSMSRemindersNowView.as_view(), name='run-patient-sms-reminders-now'),
     path('analytics/reports/', AnalyticsReportView.as_view(), name='analytics-reports'),
     path('analytics/export/', ExportReportView.as_view(), name='export-reports'),
 ]+ router.urls

--- a/appointments/views.py
+++ b/appointments/views.py
@@ -26,7 +26,7 @@ import csv
 from django.http import HttpResponse
 from rest_framework.parsers import MultiPartParser
 from .permissions import IsAdminOrSystemAdmin
-from appointments.cron import send_patient_reminders
+from appointments.cron import send_patient_reminders, send_patient_sms_reminders
 from rest_framework.permissions import IsAdminUser
 
 from .models import Appointment
@@ -619,6 +619,17 @@ class RunPatientRemindersNowView(APIView):
             return Response({"message": "Patient reminders have been sent successfully."}, status=status.HTTP_200_OK)
         except Exception as e:
             return Response({"error": f"Failed to send patient reminders: {str(e)}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+class RunPatientSMSRemindersNowView(APIView):
+    permission_classes = [IsAdminOrSystemAdmin]
+
+    def post(self, request):
+        try:
+            send_patient_sms_reminders()
+            return Response({"message": "SMS reminders have been sent successfully."}, status=status.HTTP_200_OK)
+        except Exception as e:
+            return Response({"error": f"Failed to send SMS reminders: {str(e)}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 class AutoEmailViewSet(viewsets.ModelViewSet):
     serializer_class = AutoEmailSerializer

--- a/frontend/src/pages/AutoSMSSetUpPage.js
+++ b/frontend/src/pages/AutoSMSSetUpPage.js
@@ -1,0 +1,168 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import {
+  Box,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button,
+  Alert,
+  CircularProgress,
+  Stack,
+  TextField
+} from '@mui/material';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
+
+function AutoSMSSetUpPage() {
+  const [frequency, setFrequency] = useState('weekly');
+  const [dayOfWeek, setDayOfWeek] = useState(1);
+  const [startDate, setStartDate] = useState(new Date());
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [runNowStatus, setRunNowStatus] = useState('');
+
+  useEffect(() => {
+    async function fetchSettings() {
+      setLoading(true);
+      try {
+        const token = localStorage.getItem('access_token');
+        const res = await axios.get('http://127.0.0.1:8000/api/settings/environment/', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setFrequency(res.data.auto_message_frequency || 'weekly');
+        setDayOfWeek(res.data.auto_message_day_of_week || 1);
+        
+        // Handle start date from API response
+        if (res.data.auto_message_start_date) {
+          setStartDate(new Date(res.data.auto_message_start_date));
+        } else {
+          // Set default to next day if no date is set
+          const tomorrow = new Date();
+          tomorrow.setDate(tomorrow.getDate() + 1);
+          setStartDate(tomorrow);
+        }
+      } catch (err) {
+        setStatus('Failed to load settings.');
+        console.error(err);
+      }
+      setLoading(false);
+    }
+    fetchSettings();
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setStatus('');
+    try {
+      const token = localStorage.getItem('access_token');
+      
+      // Format date to YYYY-MM-DD
+      const formattedDate = startDate.toISOString().split('T')[0];
+      
+      await axios.post(
+        'http://127.0.0.1:8000/api/settings/environment/',
+        {
+          auto_message_frequency: frequency,
+          auto_message_day_of_week: dayOfWeek,
+          auto_message_start_date: formattedDate
+        },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setStatus('Settings Saved!');
+    } catch (e) {
+      setStatus('Failed to save settings.');
+      console.error(e);
+    }
+    setSaving(false);
+  };
+  const handleRunNow = async () => {
+    setRunNowStatus('Running...');
+    try {
+      const token = localStorage.getItem('access_token');
+      await axios.post(
+        'http://127.0.0.1:8000/api/run-patient-sms-reminders-now/',
+        {},
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setRunNowStatus('SMS messages are being sent!');
+    } catch (e) {
+      setRunNowStatus('Failed to trigger SMS.');
+      console.error('Error triggering reminders:', e);
+    }
+  };
+
+  return (
+    <Box sx={{ boxShadow: 2, borderRadius: 2, bgcolor: 'background.paper', p: 3 }}>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Auto Message Frequency
+      </Typography>
+      <Stack spacing={2} sx={{ maxWidth: 300 }}>
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <DatePicker
+            label="Start Date"
+            value={startDate}
+            onChange={(newDate) => setStartDate(newDate)}
+            slotProps={{
+              textField: { 
+                fullWidth: true,
+                size: "medium",
+                helperText: "Select when to start sending automated SMS"
+              }
+            }}
+            disablePast
+            minDate={new Date()}
+          />
+        </LocalizationProvider>        <FormControl fullWidth>
+          <InputLabel id="frequency-label">Frequency</InputLabel>
+          <Select
+            labelId="frequency-label"
+            value={frequency}
+            label="Frequency"
+            onChange={(e) => setFrequency(e.target.value)}
+          >
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="bi-weekly">Bi-weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </Select>
+        </FormControl>
+        <FormControl fullWidth>
+          <InputLabel id="day-label">Day of Week</InputLabel>
+          <Select
+            labelId="day-label"
+            value={dayOfWeek}
+            label="Day of Week"
+            onChange={(e) => setDayOfWeek(Number(e.target.value))}
+            disabled={frequency === 'daily'}
+          >
+            <MenuItem value={1}>Monday</MenuItem>
+            <MenuItem value={2}>Tuesday</MenuItem>
+            <MenuItem value={3}>Wednesday</MenuItem>
+            <MenuItem value={4}>Thursday</MenuItem>
+            <MenuItem value={5}>Friday</MenuItem>
+            <MenuItem value={6}>Saturday</MenuItem>
+            <MenuItem value={0}>Sunday</MenuItem>
+          </Select>
+        </FormControl>
+        <Button variant="contained" onClick={handleSave} disabled={saving || loading}>
+          {saving ? <CircularProgress size={24} /> : 'Save Settings'}
+        </Button>
+        <Button variant="outlined" color="secondary" onClick={handleRunNow} disabled={loading}>
+          Run Now
+        </Button>
+        {status && (
+          <Alert severity={status === 'Settings Saved!' ? 'success' : 'error'}>{status}</Alert>
+        )}
+        {runNowStatus && (
+          <Alert severity={runNowStatus === 'SMS messages are being sent!' ? 'success' : 'info'}>{runNowStatus}</Alert>
+        )}
+      </Stack>
+    </Box>
+  );
+}
+
+export default AutoSMSSetUpPage;

--- a/frontend/src/pages/MessagesPage.js
+++ b/frontend/src/pages/MessagesPage.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Box, Tabs, Tab, Typography } from '@mui/material';
 import AutoEmailSetUpPage from './AutoEmailSetUpPage';
+import AutoSMSSetUpPage from './AutoSMSSetUpPage';
 import { useNavigate } from 'react-router-dom';
 import { jwtDecode } from 'jwt-decode';
 import BackButton from '../components/BackButton';
@@ -83,11 +84,7 @@ function MessagesPage() {
         </Box>
       </Box>
       {tab === 'email' && <AutoEmailSetUpPage />}
-      {tab === 'sms' && (
-        <Typography variant="body1" sx={{ p: 2 }}>
-          SMS messaging coming soon.
-        </Typography>
-      )}
+      {tab === 'sms' && <AutoSMSSetUpPage />}
     </Box>
   );
 }

--- a/poehr_scheduling_backend/settings.py
+++ b/poehr_scheduling_backend/settings.py
@@ -156,4 +156,5 @@ STRIPE_ENTERPRISE_PRICE_ID = os.getenv('STRIPE_ENTERPRISE_PRICE_ID', 'price_test
 # Django Cron Settings
 CRON_CLASSES = [
     'appointments.cron.BlastPatientReminderCronJob',
+    'appointments.cron.BlastPatientSMSReminderCronJob',
 ]


### PR DESCRIPTION
## Summary
- add automated SMS settings page to frontend
- wire SMS tab in messages page
- send SMS reminders from cron job
- allow running SMS reminders on demand via API
- include new cron class for SMS reminders

## Testing
- `pip install -q -r requirements.txt`
- `pytest -k sms -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6847a81561fc832a897eddc4ffe58f86