### PR TITLE
Add Terms & Privacy page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -30,6 +30,7 @@ import ContactPage from './pages/ContactPage';
 import EnrollmentPage from './pages/EnrollmentPage';
 import DataSecurityPage from './pages/DataSecurityPage';
 import SupportPage from './pages/SupportPage';
+import TermsPrivacyPage from './pages/TermsPrivacyPage';
 import ToastTestPage from './pages/ToastTestPage';
 import MessagesPage from './pages/MessagesPage';
 import CommunicatorPage from './pages/CommunicatorPage';
@@ -39,7 +40,7 @@ import { AnnouncementProvider } from './contexts/AnnouncementContext';
 
 function AppContent() {
   const location = useLocation();
-  const showNavbar = !['/', '/login', '/register', '/forgot-password', '/pricing', '/features', '/overview', '/about', '/contact', '/enroll', '/security', '/support', '/solutions'].includes(location.pathname);
+  const showNavbar = !['/', '/login', '/register', '/forgot-password', '/pricing', '/features', '/overview', '/about', '/contact', '/enroll', '/security', '/support', '/solutions', '/terms'].includes(location.pathname);
 
   // Add or remove body class based on whether navbar should be shown
   useEffect(() => {
@@ -51,7 +52,7 @@ function AppContent() {
   }, [showNavbar]);
   useEffect(() => {
     const body = document.body;
-    if (location.pathname === '/login' || location.pathname === '/register' || location.pathname === '/forgot-password' || location.pathname === '/pricing' || location.pathname === '/features' || location.pathname === '/overview' || location.pathname === '/about' || location.pathname === '/contact' || location.pathname === '/enroll' || location.pathname === '/support' || location.pathname === '/solutions') {
+    if (location.pathname === '/login' || location.pathname === '/register' || location.pathname === '/forgot-password' || location.pathname === '/pricing' || location.pathname === '/features' || location.pathname === '/overview' || location.pathname === '/about' || location.pathname === '/contact' || location.pathname === '/enroll' || location.pathname === '/support' || location.pathname === '/solutions' || location.pathname === '/terms') {
       body.classList.add('bg-gray-100');
     } else {
       body.classList.remove('bg-gray-100');
@@ -79,6 +80,7 @@ function AppContent() {
         <Route path="/support" element={<SupportPage />} />
         <Route path="/overview" element={<OverviewPage />} />
         <Route path="/security" element={<DataSecurityPage />} />
+        <Route path="/terms" element={<TermsPrivacyPage />} />
         <Route path="/dashboard" element={<PrivateRoute><DashboardPage /></PrivateRoute>} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />

--- a/frontend/src/TermsPrivacyPage/TermsPrivacyPage.css
+++ b/frontend/src/TermsPrivacyPage/TermsPrivacyPage.css
@@ -1,0 +1,81 @@
+/* ===================================================================
+   TERMS & PRIVACY PAGE STYLES - Consistent with other marketing pages
+   ================================================================= */
+.terms-privacy-page {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-family: "Inter", sans-serif;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.page-title-section {
+  padding: 80px 64px 60px;
+  text-align: center;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+}
+
+.page-title {
+  font-size: 48px;
+  font-weight: 800;
+  color: #1e293b;
+  margin-bottom: 16px;
+  letter-spacing: -0.02em;
+}
+
+.page-subtitle {
+  font-size: 24px;
+  font-weight: 400;
+  color: #64748b;
+  max-width: 800px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.content-section {
+  padding: 60px 64px 120px;
+  background: #ffffff;
+}
+
+.section {
+  margin-bottom: 48px;
+}
+
+.section-heading {
+  font-size: 32px;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 16px;
+}
+
+.section-text {
+  font-size: 18px;
+  color: #475569;
+  line-height: 1.6;
+}
+
+ol {
+  padding-left: 20px;
+}
+
+@media (max-width: 768px) {
+  .page-title-section {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+  .content-section {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+}
+
+@media (max-width: 480px) {
+  .page-title {
+    font-size: 32px;
+  }
+  .page-subtitle {
+    font-size: 16px;
+  }
+}

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -54,7 +54,7 @@ export const Footer = ({ pricingLink = "/pricing", featuresLink = "/features" })
             ©2025 POWER HEALTHCARE IT Systems LLC. All rights reserved.
           </div>
           <div className="footer-legal-links">
-            <a href="#terms" className="footer-legal-link">Terms &amp; Privacy</a>
+            <Link to="/terms" className="footer-legal-link">Terms &amp; Privacy</Link>
             <a href="#security" className="footer-legal-link">Security</a>
             <a href="#status" className="footer-legal-link">Status</a>
           </div>

--- a/frontend/src/pages/TermsPrivacyPage.js
+++ b/frontend/src/pages/TermsPrivacyPage.js
@@ -1,0 +1,66 @@
+import '../TermsPrivacyPage/TermsPrivacyPage.css';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export const TermsPrivacyPage = ({ className }) => {
+  return (
+    <div className={`terms-privacy-page ${className || ''}`}>
+      <Header />
+      <div className="page-title-section">
+        <h1 className="page-title">Terms of Service & Privacy Policy</h1>
+        <p className="page-subtitle">Our commitment to transparency and security</p>
+      </div>
+      <div className="content-section">
+        <div className="section">
+          <h2 className="section-heading">Contact Information</h2>
+          <p className="section-text">
+            Address<br />
+            16192 Coastal Highway<br />
+            Lewes, Delaware 19958<br />
+            Sussex County<br />
+            Phone: (301) 880-6015<br />
+            Email: <a href="mailto:info@powerhealthcareit.com">info@powerhealthcareit.com</a>
+          </p>
+        </div>
+
+        <div className="section">
+          <h2 className="section-heading">Terms of Service</h2>
+          <ol className="section-text">
+            <li><strong>Acceptance of Terms</strong> – By using the POWER Healthcare IT scheduling application ("the App"), you agree to these Terms of Service.</li>
+            <li><strong>Service Description</strong> – We provide a secure platform to help healthcare organizations manage appointments, schedules, and communications.</li>
+            <li><strong>Eligibility</strong> – Users must be at least 18 years old or authorized by a healthcare organization.</li>
+            <li><strong>User Accounts</strong> – You are responsible for maintaining your login credentials and all activity under your account.</li>
+            <li><strong>Permitted Use</strong> – The App may be used only for lawful purposes and in accordance with these Terms.</li>
+            <li><strong>Data Security and Privacy</strong> – We protect your data with industry‑standard measures. See our Privacy Policy below.</li>
+            <li><strong>Payment and Trial Period</strong> – Some features may require payment after a free trial.</li>
+            <li><strong>Intellectual Property</strong> – All content is owned by POWER Healthcare IT Systems, LLC.</li>
+            <li><strong>Termination</strong> – We may suspend or terminate access for conduct that violates these Terms.</li>
+            <li><strong>Disclaimers and Limitation of Liability</strong> – The App is provided "as is" without warranty.</li>
+            <li><strong>Changes to Terms</strong> – We may update these Terms and will notify users of significant changes.</li>
+            <li><strong>Contact</strong> – Questions about these Terms can be sent to <a href="mailto:info@powerhealthcareit.com">info@powerhealthcareit.com</a>.</li>
+          </ol>
+        </div>
+
+        <div className="section">
+          <h2 className="section-heading">Privacy Policy</h2>
+          <ol className="section-text">
+            <li><strong>Information We Collect</strong> – Account details, appointment data, usage data, and communications.</li>
+            <li><strong>How We Use Your Information</strong> – To operate and maintain the App, manage accounts and appointments, and meet legal requirements.</li>
+            <li><strong>How We Share Your Information</strong> – With trusted service providers, when required by law, or during business transfers. We do not sell personal data.</li>
+            <li><strong>Data Security</strong> – We implement reasonable safeguards such as encryption and access controls.</li>
+            <li><strong>Data Retention</strong> – Information is retained while accounts are active or as needed for legal purposes.</li>
+            <li><strong>Your Rights and Choices</strong> – You may access, update, or request deletion of your account information.</li>
+            <li><strong>Children’s Privacy</strong> – The App is not intended for direct use by children under 18.</li>
+            <li><strong>International Users</strong> – By using the App outside the U.S., you consent to information transfer to the United States.</li>
+            <li><strong>HIPAA Compliance Statement</strong> – We maintain the privacy and security of Protected Health Information as required by HIPAA.</li>
+            <li><strong>Changes to this Policy</strong> – Updates will be posted on our website or through the App.</li>
+            <li><strong>Contact Us</strong> – For privacy questions, email <a href="mailto:info@powerhealthcareit.com">info@powerhealthcareit.com</a>.</li>
+          </ol>
+        </div>
+      </div>
+      <Footer pricingLink="/pricing" featuresLink="/features" />
+    </div>
+  );
+};
+
+export default TermsPrivacyPage;


### PR DESCRIPTION
## Summary
- create Terms & Privacy page with professional layout
- link Terms & Privacy from the footer
- register `/terms` route and hide navbar on that page

## Testing
- `npm --prefix frontend test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849db03fa8c832a82a268819c7affd3