### PR TITLE
Add advanced analytics panel

### DIFF
--- a/frontend/src/pages/PatientsPage.js
+++ b/frontend/src/pages/PatientsPage.js
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import {
   Box, Stack, Typography, Button, TextField, IconButton, Tooltip, Paper, Table, TableBody, TableCell, TableContainer,
   TableHead, TableRow, Dialog, DialogTitle, DialogContent, DialogActions, MenuItem, FormControl, InputLabel, Select as MUISelect,
-  Alert, CircularProgress, Tabs, Tab, Pagination, Checkbox, Grid
+  Alert, CircularProgress, Tabs, Tab, Pagination, Checkbox, Grid, List, ListItem, ListItemText
 } from '@mui/material';
 import TodayIcon from '@mui/icons-material/Today';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -149,6 +149,16 @@ function PatientsPage() {
     'Blocked Time Slots',
     'Appointment Recurrence Report',
     'Appointment Duration Summary',  ];
+  const advancedAnalyticsReports = [
+    'Appointment Volume Trends',
+    'No-Show & Cancellation Rate',
+    'Provider Utilization Report',
+    'Patient Visit Frequency',
+    'New vs. Returning Patients',
+    'Appointment Lead Time Analysis',
+    'Patient Demographic Breakdown',
+    'Blocked vs. Booked Time Comparison'
+  ];
   const [token, setToken] = useState(null);
   const [userRole, setUserRole] = useState(null);
 
@@ -1176,7 +1186,22 @@ function PatientsPage() {
         </TableBody>
       </Table>
     </>
-  );  const handleStartChat = async (userToChatWith) => {
+  );
+
+  const renderAdvancedAnalytics = () => (
+    <>
+      <Typography variant="h6" sx={{ mb: 2 }}>Advanced Analytics Reports</Typography>
+      <List dense>
+        {advancedAnalyticsReports.map((r, idx) => (
+          <ListItem key={idx} disableGutters>
+            <ListItemText primary={r} />
+          </ListItem>
+        ))}
+      </List>
+    </>
+  );
+
+  const handleStartChat = async (userToChatWith) => {
     if (!currentUser) {
       toast.error("Current user not identified. Cannot start chat.");
       console.error("[PatientsPage] handleStartChat: currentUser is null");
@@ -1481,10 +1506,8 @@ function PatientsPage() {
               </Box>
             </Grid>
             <Grid item xs={12} md={6}>
-              <Box sx={{ boxShadow: 2, borderRadius: 2, bgcolor: 'background.paper', p: 3, minHeight: 400, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <Typography variant="h6" color="text.secondary">
-                  Analytics reporting coming soon...
-                </Typography>
+              <Box sx={{ boxShadow: 2, borderRadius: 2, bgcolor: 'background.paper', p: 3, minHeight: 400 }}>
+                {renderAdvancedAnalytics()}
               </Box>
             </Grid>
           </Grid>


### PR DESCRIPTION
## Summary
- list new advanced analytics reports alongside existing analytics
- show advanced analytics list on the right side of the analytics tab

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest -k none --maxfail=1 --collect-only` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68538c2bd850832a8daa997734f44c98